### PR TITLE
Fix golden snail stamina reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -1926,6 +1926,12 @@
 
       usedAutoReverseThisRound = false;
 
+      // Reset golden snail ability state on new game
+      goldenSnailStamina = 100;
+      snailKeyDown = false;
+      snailRegenAccum = 0;
+      lastSnailUpdate = Date.now();
+
       setAbilityVisibility();
 
       overlay.classList.remove('visible');


### PR DESCRIPTION
## Summary
- reset golden snail stamina and regen state when restarting the game

## Testing
- `npm test` *(fails: could not find package.json)*